### PR TITLE
Remove unneded definitions on Linux

### DIFF
--- a/src/common/stlink_device.h
+++ b/src/common/stlink_device.h
@@ -134,7 +134,7 @@ class StlinkDevice
     STLinkInterface *m_pStlinkInterface;
 
     // Mode for device opening: shared or exclusive
-    bool m_bOpenExclusive;
+    bool m_bOpenExclusive = false;
 
 #ifdef USING_ERRORLOG
     // Error log management

--- a/src/common/stlink_type.h
+++ b/src/common/stlink_type.h
@@ -56,19 +56,6 @@ typedef unsigned int uint32_t;
 
 #define EXPORTED_API __attribute__((visibility("default")))
 #define MAX_PATH     PATH_MAX
-#define HANDLE       void *
-#define PHANDLE      void **
-#define PVOID        void *
-#define BYTE         unsigned char
-#define CHAR         char
-#define TCHAR        char
-#define WORD         unsigned short // unsigned 16
-#define DWORD        unsigned int   // unsigned 32 bits
-#define LONG                                                                   \
-    int // int for signed 32 bits; Note that "long" is signed 32 bits on
-        // Windows, signed 64 bits on Linux/MacOS => dangerous
-#define LPSTR                char *
-#define INVALID_HANDLE_VALUE 0xFFFFFFFF
 typedef enum { FALSE = 0, TRUE } BOOL;
 #endif // WIN32
 


### PR DESCRIPTION
Remove unneded definitions on Linux as they could conflict with other libraries (for e.g. QThread in Qt5)