### PR TITLE
Fix OpenDevice after Reenumerate

### DIFF
--- a/src/common/stlink_interface.cpp
+++ b/src/common/stlink_interface.cpp
@@ -134,7 +134,7 @@ STLinkInterface::STLink_GetNbDevices(TEnumStlinkInterface IfId)
 
     libusb_device **devs; // pointer to pointer of device, used to retrieve a
                           // list of devices
-    cnt = libusb_get_device_list(ctx, &devs); // get the list of devices
+    ssize_t cnt = libusb_get_device_list(ctx, &devs); // get the list of devices
     if (cnt < 0) {
         return 0;
     }
@@ -188,7 +188,7 @@ STLinkInterface::STLink_GetDeviceInfo2(TEnumStlinkInterface IfId,
         return SS_BAD_PARAMETER;
     }
 
-    if (DevIdxInList >= cnt)
+    if (DevIdxInList >= m_nbEnumDevices)
         return SS_BAD_PARAMETER;
 
     libusb_device *dev = devices[DevIdxInList];
@@ -256,7 +256,7 @@ STLinkInterface::STLink_OpenDevice(TEnumStlinkInterface IfId,
         return SS_CMD_NOT_AVAILABLE;
     }
 
-    if (DevIdxInList >= cnt)
+    if (DevIdxInList >= m_nbEnumDevices)
         return SS_BAD_PARAMETER;
 
     libusb_device *dev = devices[DevIdxInList];

--- a/src/common/stlink_interface.h
+++ b/src/common/stlink_interface.h
@@ -118,7 +118,6 @@ class STLinkInterface
   private:
     libusb_context *ctx = nullptr; // a libusb session
     libusb_device *devices[256];
-    ssize_t cnt;
     STLinkIf_StatusT
     EnumDevicesIfRequired(uint32_t *pNumDevices, bool bForceRenum,
                           bool bClearList);


### PR DESCRIPTION
My apologies, I accidentally pushed the wrong branch yesterday, and the reference-leak fix/cleanup in my PR was missing its last part. This makes `STLink_OpenDevice` only work after a call to `STLink_GetNbDevices`.

I rebased the missing bit, GetNbDevices is now side effect free and OpenDevice works after Reenumerate, as before.